### PR TITLE
fix: the button url in README and a comment in Colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Navigate to the [Tutorials](Tutorials.ipynb) notebook to get started!
 
 If you want to try Gen immediately, click this `goolge colab` button!!
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/CanIyu/gen-quickstart-on-google-colab/blob/main/settingGenOnGColab.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/probcomp/gen-quickstart/blob/master/settingGenOnGColab.ipynb)
 
 ## TensorFlow or PyTorch integration
 

--- a/settingGenOnGColab.ipynb
+++ b/settingGenOnGColab.ipynb
@@ -50,7 +50,7 @@
         "id": "4GNum_fFIYdf"
       },
       "source": [
-        "# Currently, `Change runtime type` defaults to `julia`, but change it once to `python3` and again to `julia`\n"
+        "# Change the runtime type from the default to `julia`.\n"
       ]
     },
     {


### PR DESCRIPTION
すいません、凡ミス二つを修正しました :pray:

1. Colab内のコメントのアプデ忘れ（凡ミス）
ランタイム切り替えがPython→Juliaだけでよくなったのにその記述が更新されてなかった

2. ボタンの遷移策URLのアプデ忘れ（凡ミス）
READMEのボタンのURLをアップデートしていなかった
これはマージされた際に想定されるMITのリポジトリのipynbファイルの位置を指定しておかなければならないことに気が付いた

ボタンURLはマージ後を想定してprobcompのリポジトリを指定しているのですが、現在はマージ前のためエラーになります。
現状のColabを確認する際は以下に遷移してください！
https://colab.research.google.com/github/CanIyu/gen-quickstart/blob/update/colab-1/settingGenOnGColab.ipynb